### PR TITLE
Fix typo in homepage title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Startseite – Hochezeit Eduard & Joanne</title>
+  <title>Startseite – Hochzeit Eduard & Joanne</title>
 
   <!-- Farbvariablen und Basis‑Styles -->
   <link rel="stylesheet" href="css/variables.css">


### PR DESCRIPTION
## Summary
- fix misspelling of "Hochzeit" in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404cb19c8c832f834bb1426ca410b8