### PR TITLE
Cleanup unused CSS classes

### DIFF
--- a/css/basic.css
+++ b/css/basic.css
@@ -281,7 +281,6 @@ button:active {
 }
 
 /* Standard Container Styles - Basis für alle Sektionen */
-.container,
 .card,
 .story,
 .details,
@@ -300,7 +299,6 @@ button:active {
   box-sizing: border-box;
 }
 
-.container:hover,
 .card:hover,
 .story:hover,
 .details:hover,
@@ -313,17 +311,6 @@ button:active {
   box-shadow: var(--shadow-md);
 }
 
-/* Standard Icon Styles */
-.icon {
-  width: 24px;
-  height: 24px;
-  color: var(--color-primary);
-  transition: color var(--transition-medium) var(--transition-timing);
-}
-
-.icon:hover {
-  color: var(--color-primary-dark);
-}
 
 /* Logo */
 .logo {
@@ -665,7 +652,6 @@ body {
     margin-right: 0;
   }
 
-  .container,
   .card,
   .story,
   .details,
@@ -722,7 +708,6 @@ body {
     padding: 0 var(--space-sm);
   }
 
-  .container,
   .card,
   .story,
   .details,
@@ -741,7 +726,6 @@ body {
     max-width: var(--max-container-width);
   }
 
-  .container,
   .card,
   .story,
   .details,

--- a/css/edit-rsvp.css
+++ b/css/edit-rsvp.css
@@ -120,26 +120,6 @@
   transform: translateY(1px);
 }
 
-/* Bereich für Alterskategorien: Hintergrund, Ränder und Padding */
-.form-group.age-description {
-  background-color: var(--color-surface);
-  padding: var(--space-md);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-lg);
-}
-
-/* Überschrift innerhalb Altersbeschreibung */
-.form-group.age-description > p {
-  margin: 0;
-  font-weight: var(--fw-semibold);
-  color: var(--color-primary);
-}
-
-/* Auflistung der einzelnen Alterskategorien */
-.form-group.age-description .age-list p {
-  margin: var(--space-xs) 0;
-  font-size: var(--fs-sm);
-}
 
 /* ============================================
    Edit RSVP Stylesheet: Formular-Layout und Interaktionen

--- a/css/gifts.css
+++ b/css/gifts.css
@@ -92,17 +92,6 @@
   text-align: center;
 }
 
-.gift-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-md);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  border: var(--border-width) solid var(--color-border);
-}
-
-
 
 .gift-button {
   padding: var(--space-sm) var(--space-md);


### PR DESCRIPTION
## Summary
- remove `.age-description` rules from edit-rsvp styles
- drop unused `.container` and `.icon` selectors from basic.css
- delete `.gift-item` style from gifts.css

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68434cdb88a4832fb9d106528dd7e05e