### PR TITLE
Fix typo in homepage title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Startseite – Hochezeit Eduard & Joanne</title>
+  <title>Startseite – Hochzeit Eduard & Joanne</title>
   <meta name="description" content="Offizielle Hochzeitswebsite von Eduard und Joanne – alle Infos und die Möglichkeit zur Zusage.">
   <meta property="og:title" content="Hochzeit Eduard & Joanne">
   <meta property="og:description" content="Alle Informationen zur Hochzeit und RSVP.">


### PR DESCRIPTION
## Summary
- correct typo in index.html title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c78a687c4832fb0f53c2f5fadb484