### PR TITLE
Use env-based Firebase config and restrict Firestore rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ Upload aller Dateien auf euren Webspace.
 
 Stelle sicher, dass die Dateistruktur erhalten bleibt.
 
+Firebase-Konfiguration
+
+Die Datei js/firebase-init.js enthält Platzhalter wie __FIREBASE_API_KEY__.
+Vor einem Deployment müssen diese mit euren echten Firebase-Werten ersetzt
+werden. Setzt dazu die entsprechenden Umgebungsvariablen und führt z.B. diesen
+Build-Schritt aus:
+
+FIREBASE_API_KEY=... \
+FIREBASE_AUTH_DOMAIN=... \
+FIREBASE_PROJECT_ID=... \
+FIREBASE_STORAGE_BUCKET=... \
+FIREBASE_MESSAGING_SENDER_ID=... \
+FIREBASE_APP_ID=... \
+envsubst < js/firebase-init.js > js/firebase-init.js.tmp && \
+mv js/firebase-init.js.tmp js/firebase-init.js
+
+CI/CD-Plattformen können auf die gleiche Weise die Platzhalter während des
+Deployments ersetzen.
+
+Die Firestore-Sicherheitsregeln liegen in firestore.rules und sollten nach
+Anpassungen mit der Firebase CLI (firebase deploy --only firestore:rules)
+ausgerollt werden.
+
 Contributing
 
 Beiträge sind willkommen! Bitte öffne Issues für Fehler oder Feature-Requests und erstelle Pull Requests für Änderungen.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /gifts/{giftId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+
+    match /rsvps/{rsvpId} {
+      allow read, write: if request.auth != null;
+    }
+
+    // Deny all other access
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/js/firebase-init.js
+++ b/js/firebase-init.js
@@ -1,12 +1,12 @@
 // js/firebase-init.js
 // Gemeinsame Initialisierung von Firebase
 const firebaseConfig = {
-  apiKey: "AIzaSyBghkLs0tkWZjdMQC9RvDT8DmC5J-uXpEc",
-  authDomain: "hochzeiteduardjoanne.firebaseapp.com",
-  projectId: "hochzeiteduardjoanne",
-  storageBucket: "hochzeiteduardjoanne.firebasestorage.app",
-  messagingSenderId: "209565556740",
-  appId: "1:209565556740:web:1a227bfce08bf5dca2d551"
+  apiKey: "__FIREBASE_API_KEY__",
+  authDomain: "__FIREBASE_AUTH_DOMAIN__",
+  projectId: "__FIREBASE_PROJECT_ID__",
+  storageBucket: "__FIREBASE_STORAGE_BUCKET__",
+  messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
+  appId: "__FIREBASE_APP_ID__"
 };
 
 firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- replace hard-coded Firebase config with env placeholders
- document build step to inject Firebase config and deploy rules
- add strict Firestore rules requiring authentication

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92d5f574832fb453cd21ed8d2f93