### PR TITLE
Restrict Firestore gift access to authenticated users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,17 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /gifts/{giftId} {
-      allow read: if true;
-      allow write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if request.auth != null &&
+                   request.resource.data.keys().hasOnly([
+                     'name',
+                     'description',
+                     'imgUrl',
+                     'link',
+                     'reserved',
+                     'reserverEmail',
+                     'reservedAt'
+                   ]);
     }
 
     match /rsvps/{rsvpId} {


### PR DESCRIPTION
## Summary
- Require authentication for reading gifts
- Validate gift writes to allow only expected fields

## Testing
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac99e7ce18832fb7bd03b37b4bd387