### PR TITLE
Refactor contact styles to use base card classes

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -28,9 +28,9 @@
 
   <main class="content">
     <!-- Kontakt-Inhalte -->
-    <section class="content card">
+    <section class="content">
       <!-- Kontaktinformationen -->
-      <div class="contact-details">
+      <div class="contact-details card">
         <h2>Kontaktinformationen</h2>
         <div class="contact-card">
           <h3>Brautpaar</h3>
@@ -62,7 +62,7 @@
       </div>
 
       <!-- Kontaktformular -->
-      <div class="contact-form">
+      <div class="contact-form card">
         <h2>Kontaktformular</h2>
         <form class="form" action="/.netlify/functions/contact" method="POST">
           <div class="form-group">

--- a/css/contact.css
+++ b/css/contact.css
@@ -8,24 +8,11 @@
 .contact-details,
 .contact-form {
   flex: 1 1 300px;
-  background-color: var(--color-surface);
-  padding: var(--space-xl) var(--container-padding);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
-  transition: transform var(--transition-medium) var(--transition-timing);
-  width: 100%;
-  box-sizing: border-box;
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
   hyphens: auto;
-  margin-bottom: var(--space-sm);
-}
-
-.contact-details:hover,
-.contact-form:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
+  margin: 0 0 var(--space-sm);
 }
 
 
@@ -45,23 +32,13 @@
 
 /* Media Queries für responsive Anpassungen */
 @media (max-width: 768px) {
-
   .contact-details,
   .contact-form {
-    padding: var(--space-lg) var(--space-md);
     flex-basis: 100%;
   }
 
   .form-group input,
   .form-group textarea {
     max-width: 100%;
-  }
-}
-
-@media (max-width: 480px) {
-
-  .contact-details,
-  .contact-form {
-    padding: var(--space-md) var(--space-sm);
   }
 }


### PR DESCRIPTION
## Summary
- Remove duplicate styling from contact page and rely on shared `.card` rules
- Apply `.card` class to contact details and form elements
- Keep only contact-specific flex and word wrap adjustments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac996edb64832fae043d6ed9064db2