### PR TITLE
Refactor RSVP styles to use global form components

### DIFF
--- a/css/rsvp.css
+++ b/css/rsvp.css
@@ -18,18 +18,6 @@
      RSVP Stylesheet: Modernes Formular-Layout
      ============================================ */
   
-  /* RSVP Section */
-  .rsvp-section {
-    max-width: var(--max-container-width);
-    margin: var(--space-xl) auto;
-    padding: var(--space-xl) var(--container-padding);
-    width: 100%;
-    box-sizing: border-box;
-    background-color: var(--color-surface);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-soft);
-  }
-  
   .rsvp-container {
     max-width: 800px;
     margin: 0 auto;
@@ -57,47 +45,9 @@
     max-width: 600px;
     margin: 0 auto;
   }
-  
-  /* Form Groups */
-  .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xs);
-    background-color: var(--color-surface);
-    padding: var(--space-md);
-    border-radius: var(--radius-lg);
-    border: var(--border-width) solid var(--color-border);
-  }
-  
-  .form-group label {
-    font-size: var(--fs-md);
-    font-weight: var(--fw-medium);
-    color: var(--color-text);
-    font-family: var(--font-text);
-  }
-  
-  .form-group input,
-  .form-group textarea {
-    padding: var(--space-sm);
-    border: var(--border-width) solid var(--color-border);
-    border-radius: var(--radius-md);
-    font-size: var(--fs-md);
-    font-family: var(--font-text);
-    color: var(--color-text);
-    background-color: var(--color-surface);
-    transition: all var(--transition-medium) var(--transition-timing);
-  }
-  
-  .form-group input:focus,
-  .form-group textarea:focus {
-    outline: none;
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 2px var(--color-primary-light);
-  }
-  
+
   .form-group textarea {
     min-height: 80px;
-    resize: vertical;
   }
   
   /* Radio Buttons */
@@ -105,46 +55,6 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: var(--space-sm);
-    margin-top: var(--space-xs);
-  }
-  
-  .radio-option {
-    position: relative;
-    padding: var(--space-sm);
-    border: var(--border-width) solid var(--color-border);
-    border-radius: var(--radius-md);
-    transition: all var(--transition-medium) var(--transition-timing);
-    display: flex;
-    align-items: center;
-    gap: var(--space-xs);
-    background-color: var(--color-surface);
-  }
-  
-  .radio-option:hover {
-    border-color: var(--color-primary);
-    background-color: var(--color-primary-light);
-  }
-  
-  .radio-option input[type="radio"] {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-  
-  .radio-option span {
-    font-size: var(--fs-md);
-    color: var(--color-text);
-    cursor: pointer;
-    font-family: var(--font-text);
-    display: block;
-    width: 100%;
-    text-align: center;
-  }
-  
-  .radio-option input[type="radio"]:checked + span {
-    color: var(--color-primary);
-    font-weight: var(--fw-semibold);
   }
   
   /* Guest Fields */
@@ -175,12 +85,6 @@
     padding: var(--space-md);
     display: grid;
     gap: var(--space-md);
-  }
-  
-  .guest-content .form-group {
-    background-color: transparent;
-    padding: 0;
-    border: none;
   }
   
   /* Age Info Section */
@@ -276,30 +180,23 @@
   }
   
   /* Submit Button */
-  .btn-primary {
+  .btn--primary {
     background-color: var(--color-primary);
     color: var(--color-on-primary);
-    border: none;
-    border-radius: var(--radius-md);
-    padding: var(--space-sm) var(--space-lg);
-    font-size: var(--fs-md);
-    font-weight: var(--fw-semibold);
-    cursor: pointer;
-    transition: all var(--transition-medium) var(--transition-timing);
     width: 100%;
     max-width: 300px;
     margin: 0 auto;
   }
-  
-  .btn-primary:hover {
+
+  .btn--primary:hover {
     background-color: var(--color-primary-dark);
   }
-  
-  .btn-primary:active {
+
+  .btn--primary:active {
     transform: translateY(1px);
   }
-  
-  .btn-primary:disabled {
+
+  .btn--primary:disabled {
     background-color: var(--color-border);
     color: var(--color-text);
     cursor: not-allowed;
@@ -332,24 +229,6 @@
     cursor: not-allowed !important;
   }
   
-  .form-group.disabled .radio-option,
-  .guest-field.disabled .radio-option {
-    background-color: var(--color-bg-light) !important;
-    border-color: #ccc !important;
-    color: #888 !important;
-    cursor: not-allowed !important;
-  }
-  
-  .form-group.disabled .radio-option:hover,
-  .guest-field.disabled .radio-option:hover {
-    background-color: var(--color-bg-light) !important;
-    border-color: #ccc !important;
-  }
-  
-  .form-group.disabled .radio-option span,
-  .guest-field.disabled .radio-option span {
-    color: #888 !important;
-  }
   
   .form-group.disabled .guest-btn,
   .guest-field.disabled .guest-btn {
@@ -378,17 +257,8 @@
   
   /* Responsive Anpassungen */
   @media (max-width: 768px) {
-    .rsvp-section {
-      padding: var(--space-lg) var(--space-md);
-      margin: var(--space-lg) auto;
-    }
-    
     .rsvp-container {
       padding: 0;
-    }
-    
-    .form-group {
-      padding: var(--space-md);
     }
     
     .guest-content {
@@ -409,18 +279,9 @@
     .radio-group {
       grid-template-columns: 1fr;
     }
-    
-    .radio-option {
-      padding: var(--space-sm);
-    }
   }
-  
+
   @media (max-width: 480px) {
-    .rsvp-section {
-      padding: var(--space-md) var(--space-sm);
-      margin: var(--space-md) auto;
-    }
-    
     .rsvp-container {
       padding: 0;
     }

--- a/edit-rsvp.html
+++ b/edit-rsvp.html
@@ -105,7 +105,7 @@
           <textarea id="message" name="message" rows="4" placeholder="Möchtest du uns noch etwas mitteilen?"></textarea>
         </div>
 
-        <button type="submit" class="btn btn-primary">Änderungen speichern</button>
+        <button type="submit" class="btn btn--primary">Änderungen speichern</button>
       </form>
     </div>
   </section>

--- a/rsvp.html
+++ b/rsvp.html
@@ -105,7 +105,7 @@
           <textarea id="message" name="message" rows="4" placeholder="Möchtest du uns noch etwas mitteilen?"></textarea>
         </div>
 
-        <button type="submit" class="btn btn-primary">Absenden</button>
+        <button type="submit" class="btn btn--primary">Absenden</button>
       </form>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Remove custom RSVP section container in favour of global styles
- Reuse global form-group and radio styles; keep only grid tweaks
- Replace `.btn-primary` with `.btn--primary` modifier for submit buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9972e684832f8241d399519ad5a8