### PR TITLE
Defer template loading script

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="website">
   <link rel="stylesheet" href="css/variables.css">
   <link rel="stylesheet" href="css/basic.css">
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 </head>
 <body>
   <div id="header"></div>

--- a/admin.html
+++ b/admin.html
@@ -15,7 +15,7 @@
   <!-- Spezifisches Styling für Admin -->
   <link rel="stylesheet" href="css/admin.css">
 
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 
   <!-- Firebase SDKs -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="css/basic.css">
   <!-- Spezifisches Styling für Kontakt-Seite -->
   <link rel="stylesheet" href="css/contact.css">
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 </head>
 <body>
   <!-- Header-Include -->

--- a/edit-rsvp.html
+++ b/edit-rsvp.html
@@ -15,7 +15,7 @@
   <!-- Spezifisches Styling für RSVP -->
   <link rel="stylesheet" href="css/rsvp.css">
 
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 
   <!-- Firebase‑SDKs -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>

--- a/gifts.html
+++ b/gifts.html
@@ -16,7 +16,7 @@
   <!-- Neues Styling für Geschenke -->
   <link rel="stylesheet" href="css/gifts.css">
 
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 
   <!-- Firebase‑SDKs (compat mode) -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>

--- a/impressum.html
+++ b/impressum.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/basic.css">
   <!-- Spezifisches Styling für Impressum -->
   <link rel="stylesheet" href="css/impressum.css">
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 </head>
 <body>
   <!-- Header einbinden -->

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <!-- Farbvariablen und Basis‑Styles -->
   <link rel="stylesheet" href="css/variables.css">
   <link rel="stylesheet" href="css/basic.css">
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 
 </head>
 <body>

--- a/infos.html
+++ b/infos.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/basic.css">
   <!-- Spezifisches Styling für Infos -->
   <link rel="stylesheet" href="css/infos.css">
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 </head>
 <body>
   <!-- Header-Include -->

--- a/rsvp.html
+++ b/rsvp.html
@@ -15,7 +15,7 @@
   <!-- Spezifisches Styling für RSVP -->
   <link rel="stylesheet" href="css/rsvp.css">
 
-  <script src="js/includeTemplate.js"></script>
+  <script src="js/includeTemplate.js" defer></script>
 
   <!-- Firebase‑SDKs -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>


### PR DESCRIPTION
## Summary
- defer `includeTemplate.js` across site pages to prevent render blocking

## Testing
- `npx -p jsdom node -e "const {JSDOM}=require('jsdom'); const dom=new JSDOM('');"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*


------
https://chatgpt.com/codex/tasks/task_e_68ac99e632a4832f8f1678f2894b6ebf